### PR TITLE
remove affine host-calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,13 +1860,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6cf59af1067a3fb53fbe5c88c053764e930f932be1d71d3ffe032cbe147f59"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.0",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -1886,9 +1886,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6868896879ba532248f33598de5181522d8b3d9d724dfd230911e1a7d4822f5"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rustc-demangle"
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "sp-arkworks"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "array-bytes",
  "bitflags",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2351,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -2372,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "bytes",
  "ed25519",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "futures",
  "merlin",
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "hash-db",
  "log",
@@ -2474,12 +2474,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#2f8579e6a8b4ebdc5eaa7342b925f6ce8861579f"
+source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration-remove-affine-hostcalls#5bf523a70dad29fec7ff1f9b5090aca5f49f7623"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ lto = true
 members = ["curves/bls12_381", "curves/bls12_377", "curves/bw6_761", "curves/ed_on_bls12_377", "curves/ed_on_bls12_381", "models" ]
 
 [patch.crates-io]
-sp-io =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-arkworks =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
+sp-io =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-arkworks =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }

--- a/benchmarking/Cargo.toml
+++ b/benchmarking/Cargo.toml
@@ -10,32 +10,32 @@ panic = 'unwind'
 lto = true
 
 [patch.crates-io]
-pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-std = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-support = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-system = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-pallet-aura = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-executive = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-api = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-session = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-version = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-offchain = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-core = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-runtime = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-std = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-io = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-support = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-system = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+pallet-aura = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+pallet-balances = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-executive = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-api = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-session = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-version = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-offchain = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
+sp-inherents = { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration-remove-affine-hostcalls" }
 sp-ark-bls12-381 = { git = "https://github.com/paritytech/ark-substrate" }
 sp-ark-bls12-377 = { git = "https://github.com/paritytech/ark-substrate" }
 sp-ark-bw6-761 = { git = "https://github.com/paritytech/ark-substrate" }

--- a/curves/bls12_377/src/curves/g1.rs
+++ b/curves/bls12_377/src/curves/g1.rs
@@ -73,10 +73,11 @@ impl<H: HostFunctions> SWCurveConfig for Config<H> {
     }
 
     fn mul_affine(base: &SWAffine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<SWAffine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::bls12_377_mul_affine_g1(base.encode(), scalar.encode()).unwrap();
+        let result = H::bls12_377_mul_projective_g1(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/bls12_377/src/curves/g2.rs
+++ b/curves/bls12_377/src/curves/g2.rs
@@ -88,10 +88,11 @@ impl<H: HostFunctions> SWCurveConfig for Config<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::bls12_377_mul_affine_g2(base.encode(), scalar.encode()).unwrap();
+        let result = H::bls12_377_mul_projective_g2(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/bls12_377/src/curves/mod.rs
+++ b/curves/bls12_377/src/curves/mod.rs
@@ -28,9 +28,7 @@ pub trait HostFunctions: 'static {
     fn bls12_377_msm_g1(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bls12_377_msm_g2(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bls12_377_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn bls12_377_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bls12_377_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn bls12_377_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
 }
 
 impl<H: HostFunctions> Bls12Config for Config<H> {

--- a/curves/bls12_377/src/curves/tests.rs
+++ b/curves/bls12_377/src/curves/tests.rs
@@ -22,14 +22,8 @@ impl HostFunctions for Host {
     fn bls12_377_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::bls12_377_mul_projective_g1(base, scalar)
     }
-    fn bls12_377_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::bls12_377_mul_affine_g1(base, scalar)
-    }
     fn bls12_377_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::bls12_377_mul_projective_g2(base, scalar)
-    }
-    fn bls12_377_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::bls12_377_mul_affine_g2(base, scalar)
     }
 }
 

--- a/curves/bls12_381/src/curves/g1.rs
+++ b/curves/bls12_381/src/curves/g1.rs
@@ -166,10 +166,11 @@ impl<H: HostFunctions> SWCurveConfig for Config<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::bls12_381_mul_affine_g1(base.encode(), scalar.encode()).unwrap();
+        let result = H::bls12_381_mul_projective_g1(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/bls12_381/src/curves/g1.rs
+++ b/curves/bls12_381/src/curves/g1.rs
@@ -225,17 +225,11 @@ mod test {
         fn bls12_381_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
             sp_io::elliptic_curves::bls12_381_mul_projective_g1(base, scalar)
         }
-        fn bls12_381_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-            sp_io::elliptic_curves::bls12_381_mul_affine_g1(base, scalar)
-        }
         fn bls12_381_msm_g2(bases: Vec<u8>, bigints: Vec<u8>) -> Result<Vec<u8>, ()> {
             sp_io::elliptic_curves::bls12_381_msm_g2(bases, bigints)
         }
         fn bls12_381_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
             sp_io::elliptic_curves::bls12_381_mul_projective_g2(base, scalar)
-        }
-        fn bls12_381_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-            sp_io::elliptic_curves::bls12_381_mul_affine_g2(base, scalar)
         }
     }
 

--- a/curves/bls12_381/src/curves/g2.rs
+++ b/curves/bls12_381/src/curves/g2.rs
@@ -322,17 +322,11 @@ mod test {
         fn bls12_381_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
             sp_io::elliptic_curves::bls12_381_mul_projective_g1(base, scalar)
         }
-        fn bls12_381_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-            sp_io::elliptic_curves::bls12_381_mul_affine_g1(base, scalar)
-        }
         fn bls12_381_msm_g2(bases: Vec<u8>, bigints: Vec<u8>) -> Result<Vec<u8>, ()> {
             sp_io::elliptic_curves::bls12_381_msm_g2(bases, bigints)
         }
         fn bls12_381_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
             sp_io::elliptic_curves::bls12_381_mul_projective_g2(base, scalar)
-        }
-        fn bls12_381_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-            sp_io::elliptic_curves::bls12_381_mul_affine_g2(base, scalar)
         }
     }
 

--- a/curves/bls12_381/src/curves/g2.rs
+++ b/curves/bls12_381/src/curves/g2.rs
@@ -206,10 +206,11 @@ impl<H: HostFunctions> SWCurveConfig for Config<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::bls12_381_mul_affine_g2(base.encode(), scalar.encode()).unwrap();
+        let result = H::bls12_381_mul_projective_g2(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/bls12_381/src/curves/mod.rs
+++ b/curves/bls12_381/src/curves/mod.rs
@@ -30,9 +30,7 @@ pub trait HostFunctions: 'static {
     fn bls12_381_msm_g1(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bls12_381_msm_g2(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bls12_381_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn bls12_381_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bls12_381_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn bls12_381_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
 }
 
 impl<H: HostFunctions> Bls12Config for Config<H> {

--- a/curves/bls12_381/src/curves/tests/mod.rs
+++ b/curves/bls12_381/src/curves/tests/mod.rs
@@ -29,14 +29,8 @@ impl HostFunctions for Host {
     fn bls12_381_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::bls12_381_mul_projective_g1(base, scalar)
     }
-    fn bls12_381_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::bls12_381_mul_affine_g1(base, scalar)
-    }
     fn bls12_381_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::bls12_381_mul_projective_g2(base, scalar)
-    }
-    fn bls12_381_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::bls12_381_mul_affine_g2(base, scalar)
     }
 }
 

--- a/curves/bw6_761/src/curves/g1.rs
+++ b/curves/bw6_761/src/curves/g1.rs
@@ -79,10 +79,11 @@ impl<H: HostFunctions> SWCurveConfig for Config<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::bw6_761_mul_affine_g1(base.encode(), scalar.encode()).unwrap();
+        let result = H::bw6_761_mul_projective_g1(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/bw6_761/src/curves/g2.rs
+++ b/curves/bw6_761/src/curves/g2.rs
@@ -80,10 +80,11 @@ impl<H: HostFunctions> SWCurveConfig for Config<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::bw6_761_mul_affine_g2(base.encode(), scalar.encode()).unwrap();
+        let result = H::bw6_761_mul_projective_g2(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/bw6_761/src/curves/mod.rs
+++ b/curves/bw6_761/src/curves/mod.rs
@@ -31,8 +31,6 @@ pub trait HostFunctions: 'static {
     fn bw6_761_msm_g2(bases: Vec<u8>, bigints: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bw6_761_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn bw6_761_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn bw6_761_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn bw6_761_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
 }
 
 impl<H: HostFunctions> BW6Config for Config<H> {

--- a/curves/bw6_761/src/curves/tests.rs
+++ b/curves/bw6_761/src/curves/tests.rs
@@ -25,12 +25,6 @@ impl HostFunctions for Host {
     fn bw6_761_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::bw6_761_mul_projective_g2(base, scalar)
     }
-    fn bw6_761_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::bw6_761_mul_affine_g1(base, scalar)
-    }
-    fn bw6_761_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::bw6_761_mul_affine_g2(base, scalar)
-    }
 }
 
 test_group!(g1; crate::g1::G1Projective<super::Host>; sw);

--- a/curves/ed_on_bls12_377/src/curves/mod.rs
+++ b/curves/ed_on_bls12_377/src/curves/mod.rs
@@ -23,7 +23,6 @@ pub struct EdwardsConfig<H: HostFunctions>(PhantomData<fn() -> H>);
 
 pub trait HostFunctions: 'static {
     fn ed_on_bls12_377_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn ed_on_bls12_377_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn ed_on_bls12_377_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
 }
 

--- a/curves/ed_on_bls12_377/src/curves/mod.rs
+++ b/curves/ed_on_bls12_377/src/curves/mod.rs
@@ -86,10 +86,11 @@ impl<H: HostFunctions> TECurveConfig for EdwardsConfig<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::ed_on_bls12_377_mul_affine(base.encode(), scalar.encode()).unwrap();
+        let result = H::ed_on_bls12_377_mul_projective(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());

--- a/curves/ed_on_bls12_377/src/curves/tests.rs
+++ b/curves/ed_on_bls12_377/src/curves/tests.rs
@@ -9,9 +9,6 @@ impl HostFunctions for Host {
     fn ed_on_bls12_377_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::ed_on_bls12_377_msm(bases, scalars)
     }
-    fn ed_on_bls12_377_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::ed_on_bls12_377_mul_affine(base, scalar)
-    }
     fn ed_on_bls12_377_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::ed_on_bls12_377_mul_projective(base, scalar)
     }

--- a/curves/ed_on_bls12_381/src/curves/mod.rs
+++ b/curves/ed_on_bls12_381/src/curves/mod.rs
@@ -129,10 +129,11 @@ impl<H: HostFunctions> TECurveConfig for JubjubConfig<H> {
     }
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
-        let base: ArkScale<Affine<Self>> = (*base).into();
+        let base: Projective<Self> = (*base).into();
+        let base: ArkScale<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::ed_on_bls12_381_te_mul_affine(base.encode(), scalar.encode()).unwrap();
+        let result = H::ed_on_bls12_381_te_mul_projective(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<Projective<Self>> as Decode>::decode(&mut result.as_slice());
@@ -195,10 +196,11 @@ impl<H: HostFunctions> SWCurveConfig for JubjubConfig<H> {
     }
 
     fn mul_affine(base: &SWAffine<H>, scalar: &[u64]) -> SWProjective<H> {
-        let base: ArkScale<SWAffine<H>> = (*base).into();
+        let base: SWProjective<H> = (*base).into();
+        let base: ArkScaleProjective<SWProjective<H>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
-        let result = H::ed_on_bls12_381_sw_mul_affine(base.encode(), scalar.encode()).unwrap();
+        let result = H::ed_on_bls12_381_sw_mul_projective(base.encode(), scalar.encode()).unwrap();
 
         let result =
             <ArkScaleProjective<SWProjective<H>> as Decode>::decode(&mut result.as_slice());

--- a/curves/ed_on_bls12_381/src/curves/mod.rs
+++ b/curves/ed_on_bls12_381/src/curves/mod.rs
@@ -64,9 +64,7 @@ pub type SWConfig<H> = JubjubConfig<H>;
 pub trait HostFunctions: 'static {
     fn ed_on_bls12_381_te_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn ed_on_bls12_381_sw_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn ed_on_bls12_381_sw_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn ed_on_bls12_381_te_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
-    fn ed_on_bls12_381_te_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
     fn ed_on_bls12_381_sw_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()>;
 }
 

--- a/curves/ed_on_bls12_381/src/curves/mod.rs
+++ b/curves/ed_on_bls12_381/src/curves/mod.rs
@@ -128,7 +128,7 @@ impl<H: HostFunctions> TECurveConfig for JubjubConfig<H> {
 
     fn mul_affine(base: &Affine<Self>, scalar: &[u64]) -> Projective<Self> {
         let base: Projective<Self> = (*base).into();
-        let base: ArkScale<Projective<Self>> = base.into();
+        let base: ArkScaleProjective<Projective<Self>> = base.into();
         let scalar: ArkScale<&[u64]> = scalar.into();
 
         let result = H::ed_on_bls12_381_te_mul_projective(base.encode(), scalar.encode()).unwrap();

--- a/curves/ed_on_bls12_381/src/curves/tests.rs
+++ b/curves/ed_on_bls12_381/src/curves/tests.rs
@@ -12,14 +12,8 @@ impl HostFunctions for Host {
     fn ed_on_bls12_381_sw_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::ed_on_bls12_381_sw_msm(bases, scalars)
     }
-    fn ed_on_bls12_381_sw_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::ed_on_bls12_381_sw_mul_affine(base, scalar)
-    }
     fn ed_on_bls12_381_te_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::ed_on_bls12_381_te_mul_projective(base, scalar)
-    }
-    fn ed_on_bls12_381_te_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-        sp_io::elliptic_curves::ed_on_bls12_381_te_mul_affine(base, scalar)
     }
     fn ed_on_bls12_381_sw_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
         sp_io::elliptic_curves::ed_on_bls12_381_sw_mul_projective(base, scalar)


### PR DESCRIPTION
We remove the usage of host calls for `Affine` mul's with this PR by converting them into `Projective` first and by then calling into the host-calls for `Projective` mul's.