### PR TITLE
remove branch reference from sp-crypto-ec-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,9 +907,9 @@ checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1079,7 +1079,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1183,22 +1183,22 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -1368,17 +1368,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -1407,24 +1407,24 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
+source = "git+https://github.com/paritytech/polkadot-sdk#ea5792508e8482dc1d5d4d529daa328c3d7ec71d"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1522,7 +1522,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1587,7 +1587,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1732,7 +1732,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -1754,7 +1754,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2105,5 +2105,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -1419,12 +1419,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=achimcc/arkworks-integration#99dd1d24c73bc9ee2f2e2a7527c60f638e0ee68e"
+source = "git+https://github.com/paritytech/substrate.git#13ed4508e65992b761e4a713bd832aa38cc08ec7"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",

--- a/curves/bls12_377/Cargo.toml
+++ b/curves/bls12_377/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0", default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/polkadot-sdk", version = "0.4.0", default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 ark-ec = { version = "0.4.2", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }

--- a/curves/bls12_377/Cargo.toml
+++ b/curves/bls12_377/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration", version = "0.4.0", default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0", default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 ark-ec = { version = "0.4.2", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }

--- a/curves/bls12_381/Cargo.toml
+++ b/curves/bls12_381/Cargo.toml
@@ -21,7 +21,7 @@ ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false
 ark-serialize = { version = "0.4.2", default-features = false }
 
 [dev-dependencies] 
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0", default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/polkadot-sdk", version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }
 hex = { version = "^0.4.0", default-features = false }
 ark-ec = { version = "0.4.2", default-features = false }

--- a/curves/bls12_381/Cargo.toml
+++ b/curves/bls12_381/Cargo.toml
@@ -21,7 +21,7 @@ ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false
 ark-serialize = { version = "0.4.2", default-features = false }
 
 [dev-dependencies] 
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration", version = "0.4.0", default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }
 hex = { version = "^0.4.0", default-features = false }
 ark-ec = { version = "0.4.2", default-features = false }

--- a/curves/bw6_761/Cargo.toml
+++ b/curves/bw6_761/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0",  default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/polkadot-sdk", version = "0.4.0",  default-features = false }
 ark-ec = { version = "0.4.2", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false }

--- a/curves/bw6_761/Cargo.toml
+++ b/curves/bw6_761/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration", version = "0.4.0",  default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0",  default-features = false }
 ark-ec = { version = "0.4.2", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false }

--- a/curves/ed_on_bls12_377/Cargo.toml
+++ b/curves/ed_on_bls12_377/Cargo.toml
@@ -22,7 +22,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration", version = "0.4.0",  default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0",  default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }

--- a/curves/ed_on_bls12_377/Cargo.toml
+++ b/curves/ed_on_bls12_377/Cargo.toml
@@ -22,7 +22,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 ark-scale = { version = "0.0.3", features = ["hazmat"], default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0",  default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/polkadot-sdk", version = "0.4.0",  default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }

--- a/curves/ed_on_bls12_381_bandersnatch/Cargo.toml
+++ b/curves/ed_on_bls12_381_bandersnatch/Cargo.toml
@@ -22,7 +22,7 @@ ark-ed-on-bls12-381-bandersnatch = { version = "0.4.0", default-features = false
 ark-ec = { version = "0.4.2", default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0",  default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/polkadot-sdk", version = "0.4.0",  default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }

--- a/curves/ed_on_bls12_381_bandersnatch/Cargo.toml
+++ b/curves/ed_on_bls12_381_bandersnatch/Cargo.toml
@@ -22,7 +22,7 @@ ark-ed-on-bls12-381-bandersnatch = { version = "0.4.0", default-features = false
 ark-ec = { version = "0.4.2", default-features = false }
 
 [dev-dependencies]
-sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", "branch" = "achimcc/arkworks-integration", version = "0.4.0",  default-features = false }
+sp-crypto-ec-utils =  { git = "https://github.com/paritytech/substrate.git", version = "0.4.0",  default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false }
 ark-algebra-test-templates = { version = "0.4.2", default-features = false }


### PR DESCRIPTION
Because of the merge of PR https://github.com/paritytech/substrate/pull/13031, we can finally remove the PR branch reference for `sp-crypto-ec-utils`