### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-377-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-bls12-377",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-bls12-381",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-bn254",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "ark-bw6-761-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-bw6-761",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ark-bw6-767-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-bw6-767",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bls12-377-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bls12-381-bandersnatch-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bn254-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "ark-ed25519-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ark-models-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "ark-pallas-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "ark-secp256k1-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "ark-vesta-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-algebra-test-templates",
  "ark-ec",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-ec",
  "ark-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,24 @@
 [workspace]
 members = [
-  "curves/bls12_381",
   "curves/bls12_377",
+  "curves/bls12_381",
   "curves/bn254",
   "curves/bw6_761",
   "curves/bw6_767",
+  "curves/ed25519",
   "curves/ed_on_bls12_377",
   "curves/ed_on_bls12_381_bandersnatch",
   "curves/ed_on_bn254",
-  "curves/ed25519",
+  "curves/pallas",
+  "curves/secp256k1",
+  "curves/vesta",
   "models",
-  "test-utils", "curves/pallas", "curves/vesta", "curves/secp256k1",
+  "test-utils",
 ]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = [
   "Davide Galassi <davxy@datawok.net>",
   "Achim Schneider <achim@parity.io>",

--- a/curves/bls12_377/src/curves/g1.rs
+++ b/curves/bls12_377/src/curves/g1.rs
@@ -66,6 +66,22 @@ impl<H: CurveHooks> SWCurveConfig for Config<H> {
     fn mul_by_a(elem: Self::BaseField) -> Self::BaseField {
         <ArkConfig as SWCurveConfig>::mul_by_a(elem)
     }
+
+    #[inline(always)]
+    fn is_in_correct_subgroup_assuming_on_curve(item: &G1SWAffine<H>) -> bool {
+        if Self::cofactor_is_one() {
+            true
+        } else {
+            // Workaround for: https://github.com/arkworks-rs/algebra/issues/948
+            // Keep until https://github.com/arkworks-rs/algebra/pull/1046 is not published (arkworks > 0.5)
+            use ark_ff::Field;
+            use ark_ff::Zero;
+            // Directly use `double_and_add_affine` to avoid incorrect zero results from
+            // custom `mul_affine` implementations that reduce scalars modulo the group order.
+            ark_ec::scalar_mul::sw_double_and_add_affine(item, Self::ScalarField::characteristic())
+                .is_zero()
+        }
+    }
 }
 
 impl<H: CurveHooks> TECurveConfig for Config<H> {


### PR DESCRIPTION
Also restores the bls12-377 workaround for subgroup check.
The arkworks required changes are not published (requires ark-algebra > 0.5.0)